### PR TITLE
Add subtitle and highlight to articles

### DIFF
--- a/prisma/migrations/20250908164349_add_subtitle_and_important/migration.sql
+++ b/prisma/migrations/20250908164349_add_subtitle_and_important/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Article" ADD COLUMN "subtitle" TEXT;
+ALTER TABLE "Article" ADD COLUMN "important" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,7 +12,9 @@ model Article {
   title     String
   slug      String   @unique
   image     String?               // opcional
+  subtitle  String?               // subtítulo opcional
   content   String
+  important Boolean  @default(false)
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 }

--- a/src/app/admin/artigos/[id]/page.tsx
+++ b/src/app/admin/artigos/[id]/page.tsx
@@ -8,6 +8,8 @@ async function update(id: string, formData: FormData) {
   const title = String(formData.get("title") || "");
   const slug = String(formData.get("slug") || "");
   const image = String(formData.get("image") || "");
+  const subtitle = String(formData.get("subtitle") || "");
+  const important = formData.get("important") === "on";
   const content = String(formData.get("content") || "");
 
   await prisma.article.update({
@@ -17,6 +19,8 @@ async function update(id: string, formData: FormData) {
       slug,
       content,
       image: image || null, // se vazio, salva null (compatível com image String?)
+      subtitle: subtitle || null,
+      important,
     },
   });
 
@@ -56,12 +60,24 @@ export default async function Edit({ params }: { params: { id: string } }) {
         placeholder="URL da imagem (opcional)"
       />
 
+      <input
+        defaultValue={a.subtitle ?? ""}
+        name="subtitle"
+        className="px-3 py-2 rounded-lg token-surface border token-border"
+        placeholder="Subtítulo"
+      />
+
       <textarea
         defaultValue={a.content}
         name="content"
         className="px-3 py-2 rounded-lg token-surface border token-border min-h-[160px]"
         placeholder="Conteúdo"
       />
+
+      <label className="flex items-center gap-2 text-sm">
+        <input type="checkbox" name="important" defaultChecked={a.important} />
+        Importante
+      </label>
 
       <button
         type="submit"

--- a/src/app/admin/artigos/novo/page.tsx
+++ b/src/app/admin/artigos/novo/page.tsx
@@ -8,6 +8,8 @@ async function create(formData: FormData) {
   const title = String(formData.get("title") || "").trim();
   const slug = String(formData.get("slug") || "").trim();
   const image = String(formData.get("image") || "").trim();
+  const subtitle = String(formData.get("subtitle") || "").trim();
+  const important = formData.get("important") === "on";
   const content = String(formData.get("content") || "").trim();
 
   if (!title || !slug || !content) return;
@@ -18,6 +20,8 @@ async function create(formData: FormData) {
       slug,
       content,
       image: image || null, // compatível com image String?
+      subtitle: subtitle || null,
+      important,
     },
   });
 
@@ -51,11 +55,21 @@ export default function New() {
         placeholder="URL da imagem (opcional)"
       />
 
+      <input
+        name="subtitle"
+        className="px-3 py-2 rounded-lg token-surface border token-border"
+        placeholder="Subtítulo"
+      />
+
       <textarea
         name="content"
         className="px-3 py-2 rounded-lg token-surface border token-border min-h-[160px]"
         placeholder="Conteúdo"
       />
+
+      <label className="flex items-center gap-2 text-sm">
+        <input type="checkbox" name="important" /> Importante
+      </label>
 
       <button
         type="submit"

--- a/src/app/artigos/[slug]/page.tsx
+++ b/src/app/artigos/[slug]/page.tsx
@@ -16,6 +16,7 @@ export default async function ArticlePage({
   return (
     <article className="token-surface border token-border rounded-2xl p-6 space-y-4">
       <h1 className="text-3xl font-bold">{article.title}</h1>
+      {article.subtitle && <h2 className="text-xl">{article.subtitle}</h2>}
       <img src={article.image} alt="" className="w-full rounded-lg" />
       <p className="whitespace-pre-line">{article.content}</p>
     </article>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,9 +5,16 @@ import NewsCarousel from "@/components/NewsCarousel";
 export const dynamic = "force-dynamic";
 
 export default async function Page() {
-  const articles = await prisma.article.findMany({
-    orderBy: { createdAt: "desc" },
-  });
+  const [featured, articles] = await Promise.all([
+    prisma.article.findMany({
+      where: { important: true },
+      orderBy: { createdAt: "desc" },
+    }),
+    prisma.article.findMany({
+      where: { important: false },
+      orderBy: { createdAt: "desc" },
+    }),
+  ]);
 
   return (
     <div className="space-y-12">
@@ -25,13 +32,13 @@ export default async function Page() {
         </Link>
       </section>
 
-      {/* Carrossel de notícias se houver artigos */}
-      {articles.length > 0 && <NewsCarousel articles={articles} />}
+      {/* Carrossel de notícias se houver artigos destacados */}
+      {featured.length > 0 && <NewsCarousel articles={featured} />}
 
       {/* Lista de artigos (cards) */}
-      {articles.length > 1 && (
+      {articles.length > 0 && (
         <section className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-          {articles.slice(1).map((a) => (
+          {articles.map((a) => (
             <Link
               key={a.id}
               href={`/artigos/${a.slug}`}
@@ -46,6 +53,9 @@ export default async function Page() {
               )}
               <div className="p-4">
                 <h2 className="font-semibold leading-snug">{a.title}</h2>
+                {a.subtitle && (
+                  <p className="text-sm opacity-80">{a.subtitle}</p>
+                )}
               </div>
             </Link>
           ))}
@@ -53,7 +63,7 @@ export default async function Page() {
       )}
 
       {/* Caso não haja artigos, um placeholder simples */}
-      {articles.length === 0 && (
+      {featured.length === 0 && articles.length === 0 && (
         <div className="token-surface rounded-xl p-6 text-center border token-border">
           <p className="mb-4 opacity-80">Nenhum artigo publicado ainda.</p>
           <Link

--- a/src/components/NewsCarousel.tsx
+++ b/src/components/NewsCarousel.tsx
@@ -3,7 +3,12 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 
-type Article = { title: string; image: string; slug: string };
+type Article = {
+  title: string;
+  subtitle?: string | null;
+  image: string;
+  slug: string;
+};
 
 export default function NewsCarousel({ articles }: { articles: Article[] }) {
   const [index, setIndex] = useState(0);
@@ -34,6 +39,9 @@ export default function NewsCarousel({ articles }: { articles: Article[] }) {
         <h1 className="text-2xl sm:text-4xl font-extrabold leading-tight">
           {current.title}
         </h1>
+        {current.subtitle && (
+          <p className="text-sm sm:text-lg">{current.subtitle}</p>
+        )}
       </div>
     </Link>
   );


### PR DESCRIPTION
## Summary
- support optional subtitle and featured flag on Article model
- allow admins to set subtitle and mark articles as important
- show featured articles in carousel and display subtitles on pages

## Testing
- `npm test` *(fails: command not found)*
- `npm run build` *(fails: command not found)*
- `npx prisma migrate dev --name add_subtitle_and_important` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0112db5b4832b807ab3ff286b9f0d