### PR TITLE
Fix article image conditional rendering

### DIFF
--- a/src/app/artigos/[slug]/page.tsx
+++ b/src/app/artigos/[slug]/page.tsx
@@ -17,7 +17,9 @@ export default async function ArticlePage({
     <article className="token-surface border token-border rounded-2xl p-6 space-y-4">
       <h1 className="text-3xl font-bold">{article.title}</h1>
       {article.subtitle && <h2 className="text-xl">{article.subtitle}</h2>}
-      <img src={article.image} alt="" className="w-full rounded-lg" />
+      {article.image && (
+        <img src={article.image} alt="" className="w-full rounded-lg" />
+      )}
       <p className="whitespace-pre-line">{article.content}</p>
     </article>
   );


### PR DESCRIPTION
## Summary
- render article image only when provided to prevent empty tags

## Testing
- `npm test` *(fails: command not found)*
- `npm run build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c024837568832b915cf6c6e47a9ade