### PR TITLE
fix: handle missing database url during builds

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,15 +1,40 @@
 import { PrismaClient } from "@prisma/client";
 
-const g = globalThis as unknown as { prisma?: PrismaClient };
+// Prevent Prisma from initializing during builds when no database
+// connection string is available. This avoids build-time failures on
+// platforms like Vercel where `DATABASE_URL` might only be set at
+// runtime. When the variable is missing we return a proxy that throws
+// a helpful error if the client is actually used.
+const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient };
 
-export const prisma =
-  g.prisma ??
-  new PrismaClient({
-    datasources: {
-      db: {
-        url: process.env.DATABASE_URL as string,
+function createPrismaClient(): PrismaClient {
+  if (!process.env.DATABASE_URL) {
+    return new Proxy(
+      {},
+      {
+        get() {
+          throw new Error(
+            "DATABASE_URL is not set. Define it to enable database access."
+          );
+        },
+      }
+    ) as PrismaClient;
+  }
+
+  return (
+    globalForPrisma.prisma ??
+    new PrismaClient({
+      datasources: {
+        db: {
+          url: process.env.DATABASE_URL,
+        },
       },
-    },
-  });
+    })
+  );
+}
 
-if (process.env.NODE_ENV !== "production") g.prisma = prisma;
+export const prisma = createPrismaClient();
+
+if (process.env.NODE_ENV !== "production" && process.env.DATABASE_URL) {
+  globalForPrisma.prisma = prisma;
+}


### PR DESCRIPTION
## Summary
- guard prisma initialization when `DATABASE_URL` is absent

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c047265b60832ba6477bdad9303acd