### PR TITLE
fix: handle missing database url during builds

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,15 +1,40 @@
 import { PrismaClient } from "@prisma/client";
 
-const g = globalThis as unknown as { prisma?: PrismaClient };
+// Lazily instantiate Prisma so builds without a DATABASE_URL do not fail.
+// The real client is only created when first used at runtime and the
+// environment variable is available.
+const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient };
 
-export const prisma =
-  g.prisma ??
-  new PrismaClient({
-    datasources: {
-      db: {
-        url: process.env.DATABASE_URL as string,
-      },
+let prismaInstance: PrismaClient | undefined = globalForPrisma.prisma;
+
+export const prisma = new Proxy(
+  {},
+  {
+    get(_target, prop) {
+      if (!prismaInstance) {
+        if (!process.env.DATABASE_URL) {
+          throw new Error(
+            "DATABASE_URL is not set. Define it to enable database access."
+          );
+        }
+
+        prismaInstance =
+          globalForPrisma.prisma ??
+          new PrismaClient({
+            datasources: {
+              db: {
+                url: process.env.DATABASE_URL,
+              },
+            },
+          });
+
+        if (process.env.NODE_ENV !== "production") {
+          globalForPrisma.prisma = prismaInstance;
+        }
+      }
+
+      // @ts-expect-error dynamic access on the Prisma proxy
+      return prismaInstance[prop];
     },
-  });
-
-if (process.env.NODE_ENV !== "production") g.prisma = prisma;
+  }
+) as PrismaClient;


### PR DESCRIPTION
## Summary
- guard prisma initialization when `DATABASE_URL` is absent
- lazily create the Prisma client so runtime deployments use the real database when available

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c047265b60832ba6477bdad9303acd